### PR TITLE
Relax omniauth gem version requirements

### DIFF
--- a/lib/omniauth-yahoo-oauth2.rb
+++ b/lib/omniauth-yahoo-oauth2.rb
@@ -1,1 +1,2 @@
 require 'omniauth/yahoo_oauth2'
+require 'omniauth/aol_oauth2'

--- a/lib/omniauth/aol_oauth2.rb
+++ b/lib/omniauth/aol_oauth2.rb
@@ -1,0 +1,1 @@
+require 'omniauth/strategies/aol_oauth2'

--- a/lib/omniauth/strategies/aol_oauth2.rb
+++ b/lib/omniauth/strategies/aol_oauth2.rb
@@ -1,0 +1,25 @@
+# lib/omniauth/strategies/aol_oauth2.rb
+require_relative './yahoo_oauth2'
+
+module OmniAuth
+  module Strategies
+    class AolOAuth2 < YahooOAuth2
+      option :name, "aol"
+
+      # I don't remember if OmniAuth deep merges options, but it's better to
+      # duplicate `authorize_url` and `token_url` than to duplicate the entire class.  :)
+      option :client_options, {
+        site:              "https://api.login.aol.com",
+        authorize_url:     "/oauth2/request_auth",
+        token_url:         "/oauth2/get_token",
+      }
+
+      option :allowed_jwt_issuers, %w[
+        https://api.login.aol.com
+        api.login.aol.com
+        login.aol.com
+      ]
+    end
+  end
+end
+

--- a/lib/omniauth/strategies/yahoo_oauth2.rb
+++ b/lib/omniauth/strategies/yahoo_oauth2.rb
@@ -5,15 +5,15 @@ require 'omniauth/strategies/oauth2'
 
 module OmniAuth
   module Strategies
-    class YahooOauth2 < OmniAuth::Strategies::OAuth2
+    class YahooOAuth2 < OmniAuth::Strategies::OAuth2
 
       OPEN_ID_CONNECT_SCOPES = "openid,profile,email"
 
-      ALLOWED_ISSUERS = %w[
+      option :allowed_jwt_issuers, %w[
         https://api.login.yahoo.com
         api.login.yahoo.com
         login.yahoo.com
-      ].freeze
+      ]
 
       option :name, 'yahoo'
 
@@ -134,7 +134,7 @@ module OmniAuth
           # JWT.decode is false since no verification key is provided.
           ::JWT::Verify.verify_claims(decoded,
                                       verify_iss: true,
-                                      iss: ALLOWED_ISSUERS,
+                                      iss: options.allowed_jwt_issuers,
                                       verify_aud: true,
                                       aud: options.client_id,
                                       verify_sub: false,
@@ -151,3 +151,6 @@ module OmniAuth
     end
   end
 end
+
+# for backwards compatibility (doesn't work)
+YahooOauth2 = OmniAuth::Strategies::YahooOAuth2

--- a/lib/omniauth/strategies/yahoo_oauth2.rb
+++ b/lib/omniauth/strategies/yahoo_oauth2.rb
@@ -149,8 +149,8 @@ module OmniAuth
       end
 
     end
+
+    # for backwards compatibility
+    YahooOauth2 = OmniAuth::Strategies::YahooOAuth2
   end
 end
-
-# for backwards compatibility (doesn't work)
-YahooOauth2 = OmniAuth::Strategies::YahooOAuth2

--- a/lib/omniauth/strategies/yahoo_oauth2.rb
+++ b/lib/omniauth/strategies/yahoo_oauth2.rb
@@ -132,17 +132,11 @@ module OmniAuth
 
           # We have to manually verify the claims because the third parameter to
           # JWT.decode is false since no verification key is provided.
-          ::JWT::Verify.verify_claims(decoded,
-                                      verify_iss: true,
-                                      iss: options.allowed_jwt_issuers,
-                                      verify_aud: true,
-                                      aud: options.client_id,
-                                      verify_sub: false,
-                                      verify_expiration: true,
-                                      verify_not_before: true,
-                                      verify_iat: true,
-                                      verify_jti: false,
-                                      leeway: options[:jwt_leeway])
+          ::JWT::Claims.verify_payload!(decoded,
+                                        iss: options.allowed_jwt_issuers,
+                                        aud: options.client_id,
+                                        exp: { leeway: options.jwt_leeway },
+                                        nbf: { leeway: options.jwt_leeway })
 
           decoded
         end

--- a/lib/omniauth/yahoo_oauth2/version.rb
+++ b/lib/omniauth/yahoo_oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
-  module YahooOauth2
-    VERSION = '1.2.0'
+  module YahooOAuth2
+    VERSION = '1.3.0'
   end
 end

--- a/omniauth-yahoo-oauth2.gemspec
+++ b/omniauth-yahoo-oauth2.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path(File.join('..', 'lib', 'omniauth', 'yahoo_oauth2', 'version'), __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'omniauth', '~> 1.1'
+  gem.add_runtime_dependency 'omniauth', '>= 1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
   gem.add_development_dependency 'bundler', '~> 1.0'
 

--- a/omniauth-yahoo-oauth2.gemspec
+++ b/omniauth-yahoo-oauth2.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.name          = 'omniauth-yahoo-oauth2'
   gem.require_paths = ['lib']
-  gem.version       = OmniAuth::YahooOauth2::VERSION
+  gem.version       = OmniAuth::YahooOAuth2::VERSION
 end

--- a/omniauth-yahoo-oauth2.gemspec
+++ b/omniauth-yahoo-oauth2.gemspec
@@ -3,6 +3,7 @@ require File.expand_path(File.join('..', 'lib', 'omniauth', 'yahoo_oauth2', 'ver
 Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth', '>= 1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
+  gem.add_runtime_dependency 'jwt', '>= 2.9.2'
   gem.add_development_dependency 'bundler', '~> 1.0'
 
   gem.authors       = ['Amir Manji']


### PR DESCRIPTION
omniauth v2.0.0 was recently released, so this allows it to be upgraded. v2.0.0 _finally_ fixes CVE-2015-9284 by default and without hacky workarounds, so I hope most apps will be upgrading ASAP.

This _seems_ to be working just fine with the latest version (I haven't finished my testing yet, so I'll try to remember to update this PR in the next couple of days).